### PR TITLE
SUMO-241085 Keeps tag ordering fix while generating tf configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### [v1.3](https://github.com/OpenSLO/slogen/releases/tag/v1.3)
+
+- **Fix** : Prevents reordering of slo tags on generating terraform configuration
+
+
 ### [v1.2](https://github.com/OpenSLO/slogen/releases/tag/v1.2)
 
 #### Support for Labels

--- a/README.md
+++ b/README.md
@@ -137,5 +137,5 @@ slogen list -c
 Slogen supports `labels` from the OpenSLO config and applies them as tags to the native SLOs created in the vendor environment (Sumologic). In the OpenSLO spec, `metadata.labels` is an optional map of keys to one or more values. Slogen supports only one value per unique key. The first value specified in the list of values will be considered.
 
 ### Change Log
-- [New feature and fixes in v1.2](CHANGELOG.md)
+- [Bug fixes in v1.3](CHANGELOG.md)
 

--- a/libs/sumologic/native.go
+++ b/libs/sumologic/native.go
@@ -3,6 +3,7 @@ package sumologic
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -130,17 +131,20 @@ func ConvertToSumoSLO(slo specs.OpenSLOSpec) (*SLO, error) {
 	indicator, _ := giveSLI(slo)
 
 	tagsMap := make(map[string]string)
+	var tagKeys []string
 
 	for k := range slo.ObjectHeader.Metadata.Labels {
 		if len(slo.ObjectHeader.Metadata.Labels[k]) > 0 {
 			tagsMap[k] = slo.ObjectHeader.Metadata.Labels[k][0]
-
+			tagKeys = append(tagKeys, k)
 		}
 	}
 
+	sort.Strings(tagKeys)
+
 	tagsStr := ""
 	c := 0
-	for k := range tagsMap {
+	for _, k := range tagKeys {
 		tagsStr += "\"" + k + "\" = \"" + tagsMap[k] + "\""
 		if c < len(tagsMap)-1 {
 			tagsStr += ", "


### PR DESCRIPTION
Fixed the tags ordering to be lexicographically sorted by keys every time

Testing - Verified that tags are not ordered randomly on each tf config generation.